### PR TITLE
Fixed hardcoded namespace

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -4,4 +4,4 @@ stdbuf -o0 curl -sSk -H "Authorization: Bearer $KUBE_TOKEN"   https://$KUBERNETE
 line=`echo $line | sed 's/\"//g'`
 export cm_name=`echo $line | cut -d : -f1`
 export version=`echo $line |cut -d : -f2`
-kubectl --namespace=$MY_POD_NAMESPACE get deployments -o json  |  jq  --unbuffered   '.items[]|select(.spec.template.spec.containers[0].envFrom[0].configMapRef.name == env.cm_name)|.metadata.name'| xargs -I {} kubectl --namespace=dev patch deployment {}  --type json  -p='[{"op": "replace", "path": "/spec/template/metadata/labels/version", "value":'"'$version'"'}]'  ;done
+kubectl --namespace=$MY_POD_NAMESPACE get deployments -o json  |  jq  --unbuffered   '.items[]|select(.spec.template.spec.containers[0].envFrom[0].configMapRef.name == env.cm_name)|.metadata.name'| xargs -I {} kubectl --namespace=$MY_POD_NAMESPACE patch deployment {}  --type json  -p='[{"op": "replace", "path": "/spec/template/metadata/labels/version", "value":'"'$version'"'}]'  ;done


### PR DESCRIPTION
The namespace `dev` is hardcoded in the `updater.sh` script, which means no changes get applied if the pod that will be updated is in a differently named namespace.