### PR TITLE
Updated jq filter to support more configMap use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Bash script that will query **Kubernetes** watch api for **configmaps** change
 
 `kubectl create -f https://raw.githubusercontent.com/aabed/kubernetes-configmap-rollouts/master/kubernetes-configmap-rollouts.yaml`
 
+**Note:** This module updates deployments based on `/spec/template/metadata/labels/version`, please make sure your deployments contain this label.
+
 ## More
 
 Check the opened issue on kubernetes repo https://github.com/kubernetes/kubernetes/issues/22368

--- a/updater.sh
+++ b/updater.sh
@@ -4,4 +4,11 @@ stdbuf -o0 curl -sSk -H "Authorization: Bearer $KUBE_TOKEN"   https://$KUBERNETE
 line=`echo $line | sed 's/\"//g'`
 export cm_name=`echo $line | cut -d : -f1`
 export version=`echo $line |cut -d : -f2`
-kubectl --namespace=$MY_POD_NAMESPACE get deployments -o json  |  jq  --unbuffered   '.items[]|select(.spec.template.spec.containers[0].envFrom[0].configMapRef.name == env.cm_name)|.metadata.name'| xargs -I {} kubectl --namespace=$MY_POD_NAMESPACE patch deployment {}  --type json  -p='[{"op": "replace", "path": "/spec/template/metadata/labels/version", "value":'"'$version'"'}]'  ;done
+echo "Rerolling Deployments that use ConfigMap: $cm_name"
+kubectl --namespace=$MY_POD_NAMESPACE get deployments -o json  |\
+# filter by deployments that use the updated secret / configmap
+jq  --unbuffered   '.items[]|select(.spec.template.spec.containers[]?.env[]?.valueFrom.configMapKeyRef.name == env.cm_name or .spec.template.spec.containers[]?.envFrom[]?.configMapRef.name == env.cm_name)|.metadata.name' |\
+# get rid of duplicates
+uniq |\
+# trigger deployment rollouts
+xargs -I {} kubectl --namespace=$MY_POD_NAMESPACE patch deployment {}  --type json  -p='[{"op": "replace", "path": "/spec/template/metadata/labels/version", "value":'"'$version'"'}]'  ;done


### PR DESCRIPTION
The current jq filter only triggers reloads on Deployments using `configMapRef` and only checks the first env variable.
I've updated it to check all environment variables and to work on my use case, using `valueFrom.configMapKeyRef` which is referenced in K8S documentation.
Also, I've updated README.md to clarify the need for `version` label to be present on the deployment yaml.

PS: I will update this script to support secrets as well, let me know if that change is welcome here or if a separate module should be created.