### PR TITLE
changed jq select approach / added alpine version

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,10 @@
+FROM alpine
+RUN apk upgrade --update && \
+     apk add curl bash coreutils jq
+
+RUN curl -LO https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
+    mv jq-linux64 jq && chmod +x jq && mv jq /usr/local/bin && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl && \
+    chmod +x kubectl && mv kubectl /usr/local/bin
+COPY updater.sh /
+CMD /updater.sh

--- a/updater.sh
+++ b/updater.sh
@@ -10,7 +10,7 @@ export version=`echo $line |cut -d : -f2`
 echo "Rerolling Deployments that use ConfigMap: $cm_name"
 kubectl --namespace=$MY_POD_NAMESPACE get deployments -o json  |\
 # filter by deployments that use the updated configmap
-jq  --unbuffered   '.items[]|select(.spec.template.spec.containers[]?.env[]?.valueFrom.configMapKeyRef.name == env.cm_name or .spec.template.spec.containers[]?.envFrom[]?.configMapRef.name == env.cm_name)|.metadata.name' |\
+jq  --unbuffered   '.items[]|select(.spec.template.spec.containers[]?.env[]?.valueFrom.configMapKeyRef.name == env.cm_name), select(.spec.template.spec.containers[]?.envFrom[]?.configMapRef.name == env.cm_name)|.metadata.name' |\
 # get rid of duplicates
 uniq |\
 # trigger deployment rollouts
@@ -24,7 +24,7 @@ export version=`echo $line |cut -d : -f2`
 echo "Rerolling Deployments that use Secrets: $cm_name"
 kubectl --namespace=$MY_POD_NAMESPACE get deployments -o json  |\
 # filter by deployments that use the updated secret
-jq  --unbuffered   '.items[]|select(.spec.template.spec.containers[]?.env[]?.valueFrom.secretKeyRef.name == env.cm_name or .spec.template.spec.containers[]?.envFrom[]?.secretRef.name == env.cm_name)|.metadata.name' |\
+jq  --unbuffered   '.items[]|select(.spec.template.spec.containers[]?.env[]?.valueFrom.secretKeyRef.name == env.cm_name), select(.spec.template.spec.containers[]?.envFrom[]?.secretRef.name == env.cm_name)|.metadata.name' |\
 # get rid of duplicates
 uniq |\
 # trigger deployment rollouts


### PR DESCRIPTION
This PR aims to change the approach of `jq select` since the approach with conditional `or` did not worked for me. The jq queries for CM and Secrets were resulting in an empty/null value so the kubectl patch was not able to do anything.

After a little research about `jq` I found an approach with multiple selects on same statement which worked as expected. (Ref. https://stackoverflow.com/questions/51970546/using-jq-select-multiple-keys-and-return-them-in-an-array#51975841)

Also, I've added a Dockerfile with alpine as base image.